### PR TITLE
Add `git remote` new alias

### DIFF
--- a/gittools.sh
+++ b/gittools.sh
@@ -270,6 +270,7 @@ if [ -n "$ENABLE_ALIAS" ] && [ "$ENABLE_ALIAS" = true ]; then
     alias greset="git reset"
     alias grm="git rm"
     alias gmv="git mv"
+    alias gremote="git remote"
 
     function gpush ()
     {


### PR DESCRIPTION
IMHO a new `gremote` alias will be usefull, specially when you are creating new Git projects and need to add new remote servers, or verify any entry that you have now.
